### PR TITLE
fix Blast script indenting bug and baseCommand in cwl

### DIFF
--- a/CWL-Blast/count_nucleotides.cwl
+++ b/CWL-Blast/count_nucleotides.cwl
@@ -1,7 +1,7 @@
 #this script will call a python program to count nucleotide base 
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: python
+baseCommand: python3
 stdout: NucleoCount.txt
 
 requirements:

--- a/CWL-Blast/extract_contigs.cwl
+++ b/CWL-Blast/extract_contigs.cwl
@@ -1,7 +1,7 @@
 #this script will extract the contigs of interest
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: python
+baseCommand: python3
 stdout: extracted_contigs.txt
 
 requirements:

--- a/CWL-Blast/extract_headers.cwl
+++ b/CWL-Blast/extract_headers.cwl
@@ -1,7 +1,7 @@
 #this script will call a python program to extract headers from the blast result
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: python
+baseCommand: python3
 stdout: Headers.txt
 
 requirements:

--- a/CWL-Blast/scripts/Count_Nucleotides.py
+++ b/CWL-Blast/scripts/Count_Nucleotides.py
@@ -9,11 +9,11 @@ cur_seq = []
 linear = []
 for line in contigfile:
     if line.startswith(">") and cur_contig == '':
-	linear = line.split(" ")
+        linear = line.split(" ")
         cur_contig = linear[0][1:].strip()
     elif line.startswith(">") and cur_contig != '':
         dic[cur_contig] = ''.join(cur_seq)
-	linear = line.split(" ")
+        linear = line.split(" ")
         cur_contig = linear[0][1:].strip()
         cur_seq = []
     else:
@@ -29,4 +29,4 @@ count = 0
 for lin in listofuniqueidentifiers:
     if lin.rstrip() in dic:
         count = len(dic[lin.rstrip()]) + count
-print count
+print(count)

--- a/CWL-Blast/scripts/Extract_Contigs.py
+++ b/CWL-Blast/scripts/Extract_Contigs.py
@@ -9,11 +9,11 @@ cur_seq = []
 linear = []
 for line in contigfile:
     if line.startswith(">") and cur_contig == '':
-	linear = line.split(" ")
+        linear = line.split(" ")
         cur_contig = linear[0][1:].strip()
     elif line.startswith(">") and cur_contig != '':
         dic[cur_contig] = ''.join(cur_seq)
-	linear = line.split(" ")
+        linear = line.split(" ")
         cur_contig = linear[0][1:].strip()
         cur_seq = []
     else:
@@ -30,7 +30,7 @@ final = ""
 count = 0
 for lin in listofuniqueidentifiers:
     if lin.rstrip() in dic:
-	final = final + ">" + lin + dic[lin.rstrip()] + "\n" 
+        final = final + ">" + lin + dic[lin.rstrip()] + "\n" 
         #count = len(dic[lin.rstrip()]) + count
 
 outputfilename = sys.argv[3]


### PR DESCRIPTION
The latest `ncbi/blast` image could not find `python` command.

```bash
INFO [job step3] /tmp/20fskiuz$ docker \                                                                                                                                                                                                                 
    run \                                                                                                                                                                                                                                                
    -i \                                                                                                                                                                                                                                                 
    --mount=type=bind,source=/tmp/20fskiuz,target=/kcJHVr \                                                                                                                                                                                              
    --mount=type=bind,source=/tmp/5m1blchh,target=/tmp \                                                                    
    --mount=type=bind,source=/root/RunningWorkflows-on-the-GoogleCloud/CWL-Blast/data/sample.fa,target=/var/lib/cwl/stgc692eec9-c6c2-4aae-9850-d2065457bcd4/sample.fa,readonly \
    --mount=type=bind,source=/tmp/k13dpx66/Headers.txt,target=/var/lib/cwl/stgd4487510-563e-41b5-9764-2ba9740b6ef4/Headers.txt,readonly \
    --mount=type=bind,source=/root/RunningWorkflows-on-the-GoogleCloud/CWL-Blast/scripts/Count_Nucleotides.py,target=/var/lib/cwl/stgf1396cb1-7d40-4bd7-a15c-f48c26c8d799/Count_Nucleotides.py,readonly \
    --workdir=/kcJHVr \                                                                                                     
    --read-only=true \                                                                                                      
    --log-driver=none \                                                                                                     
    --user=0:0 \                                                                                                            
    --rm \                                                                                                                  
    --cidfile=/tmp/l2r0o4rv/20241106141521-961423.cid \                                                                     
    --env=TMPDIR=/tmp \                                                                                                     
    --env=HOME=/kcJHVr \                                                                                                    
    ncbi/blast:latest \                                                                                                     
    /bin/sh \                                                                                                               
    -c \                                                                                                                    
    'python' '/var/lib/cwl/stgf1396cb1-7d40-4bd7-a15c-f48c26c8d799/Count_Nucleotides.py' '/var/lib/cwl/stgc692eec9-c6c2-4aae-9850-d2065457bcd4/sample.fa' '/var/lib/cwl/stgd4487510-563e-41b5-9764-2ba9740b6ef4/Headers.txt' > 'NucleoCount.txt' > /tmp/2
0fskiuz/NucleoCount.txt
/bin/sh: 1: python: not found
```

The origin Blast python scripts contain indentation errors under unix systems.

https://github.com/isb-cgc/RunningWorkflows-on-the-GoogleCloud/blob/4008d86f3ccd81bef3ec78d69d484c7dcf57393a/CWL-Blast/scripts/Extract_Contigs.py#L10C1-L13C43